### PR TITLE
Fix loading localProperties.properties and loggers init

### DIFF
--- a/core/src/main/java/hwu/elixir/scrape/scraper/ScraperCore.java
+++ b/core/src/main/java/hwu/elixir/scrape/scraper/ScraperCore.java
@@ -59,7 +59,7 @@ public abstract class ScraperCore {
 
 	private WebDriver driver;
  
-	private static Logger logger = LoggerFactory.getLogger(System.class.getName());
+	private static Logger logger = LoggerFactory.getLogger(ScraperCore.class.getName());
 	
 	public ScraperCore() {
 		driver = ChromeDriverCreator.getInstance();

--- a/core/src/main/java/hwu/elixir/scrape/scraper/ScraperFilteredCore.java
+++ b/core/src/main/java/hwu/elixir/scrape/scraper/ScraperFilteredCore.java
@@ -51,7 +51,7 @@ import hwu.elixir.utils.Helpers;
  */
 public class ScraperFilteredCore extends ScraperCore {
 
-	private static Logger logger = LoggerFactory.getLogger(System.class.getName());
+	private static Logger logger = LoggerFactory.getLogger(ScraperFilteredCore.class.getName());
 	private int countOfJSONLD = 0; // number of JSON-LD blocks found in HTML
 	
 	/**

--- a/core/src/main/java/hwu/elixir/scrape/scraper/ScraperUnFilteredCore.java
+++ b/core/src/main/java/hwu/elixir/scrape/scraper/ScraperUnFilteredCore.java
@@ -31,7 +31,7 @@ import hwu.elixir.scrape.exceptions.SeleniumException;
  */
 public class ScraperUnFilteredCore extends ScraperCore {
 	
-	private static Logger logger = LoggerFactory.getLogger(System.class.getName());
+	private static Logger logger = LoggerFactory.getLogger(ScraperUnFilteredCore.class.getName());
 
 	/**
 	 * Extract schema markup in JSON-LD form from a given URL. Will ignore all other

--- a/core/src/main/java/hwu/elixir/scrape/scraper/examples/SingleURLScraper.java
+++ b/core/src/main/java/hwu/elixir/scrape/scraper/examples/SingleURLScraper.java
@@ -18,7 +18,7 @@ import hwu.elixir.scrape.scraper.ScraperFilteredCore;
 public class SingleURLScraper extends ScraperFilteredCore {
 
 	private static String outputFolder = System.getProperty("user.home");
-	private static Logger logger = LoggerFactory.getLogger(System.class.getName());
+	private static Logger logger = LoggerFactory.getLogger(SingleURLScraper.class.getName());
 
 	/**
 	 * Scrape a given URL and write to file in the home directory. Output will be in NQuads format.

--- a/core/src/main/java/hwu/elixir/scrape/scraper/examples/SingleURLUnfilteredScraper.java
+++ b/core/src/main/java/hwu/elixir/scrape/scraper/examples/SingleURLUnfilteredScraper.java
@@ -11,7 +11,7 @@ import hwu.elixir.scrape.scraper.ScraperUnFilteredCore;
 
 public class SingleURLUnfilteredScraper extends ScraperUnFilteredCore {
 	
-	private static Logger logger = LoggerFactory.getLogger(System.class.getName());
+	private static Logger logger = LoggerFactory.getLogger(SingleURLUnfilteredScraper.class.getName());
 	
 	public void scrapeASingleUnfilteredURL(String url) {
 		String jsonLD = "nothing scraped";

--- a/core/src/main/java/hwu/elixir/utils/ChromeDriverCreator.java
+++ b/core/src/main/java/hwu/elixir/utils/ChromeDriverCreator.java
@@ -23,7 +23,7 @@ public class ChromeDriverCreator {
 	
 	private volatile static WebDriver driver = null;
 	private static ChromeOptions chromeOptions = new ChromeOptions();
-	private static Logger logger = LoggerFactory.getLogger(System.class.getName());
+	private static Logger logger = LoggerFactory.getLogger(ChromeDriverCreator.class.getName());
 	
 	static {
 		ClassLoader classLoader = ChromeDriverCreator.class.getClassLoader();

--- a/core/src/main/java/hwu/elixir/utils/CompareNQ.java
+++ b/core/src/main/java/hwu/elixir/utils/CompareNQ.java
@@ -37,7 +37,7 @@ public class CompareNQ {
 	private ArrayList<String> quads1;
 	private ArrayList<String> quads2;
 
-	private static Logger logger = LoggerFactory.getLogger(System.class.getName());
+	private static Logger logger = LoggerFactory.getLogger(CompareNQ.class.getName());
 	
 	public boolean compare(File file1, File file2) throws FileNotFoundException, IOException {
 


### PR DESCRIPTION
This is a minor change following issue #52 that I just submitted. That allows loading the localProperties.properites without error due to the missing counter.
I also moved the loading of the properties into the main() which, I guess, makes more sense that in the readFileList(). I let you decide if you like that or not.

Franck.