### PR TITLE
Log message now gives path and filename in one go

### DIFF
--- a/core/src/main/java/hwu/elixir/scrape/scraper/ScraperCore.java
+++ b/core/src/main/java/hwu/elixir/scrape/scraper/ScraperCore.java
@@ -237,7 +237,7 @@ public abstract class ScraperCore {
 	 */
 	protected void displayResult(String url, boolean result, String outputFolder, long CC) {
 		if (result) {
-			logger.info(url + " was successfully scraped and written to " + outputFolder + " with filename " + CC + ".nq");
+			logger.info(url + " was successfully scraped and written to " + outputFolder + CC + ".nq");
 		} else {
 			logger.error(url + " was NOT successfully scraped.");
 		}


### PR DESCRIPTION
This means that the log message can be directly copied and used to look up the file